### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=14.16.0",
-    "npm": ">=6.0.0"
+    "node": ">=16",
+    "npm": ">=7"
   },
   "main": "main.js",
   "repository": {


### PR DESCRIPTION
adapter core 3.x.x isknown to fail durign installation on node 14 as npm 6 does  not install peerDependencies. So this adapter requires node 16 or newer.